### PR TITLE
Instance name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.3 - 2018-10-05
+### Fixed
+- Instances using IDs rather than names
+
 ## 0.1.2 - 2018-10-01
 ### Added
 - Tablespace whitelist configuration parameter

--- a/src/inventory.go
+++ b/src/inventory.go
@@ -11,7 +11,7 @@ import (
 
 // collectInventory queries the database for the inventory items, then populates
 // the integration with the results
-func collectInventory(db *sql.DB, wg *sync.WaitGroup, i *integration.Integration) {
+func collectInventory(db *sql.DB, wg *sync.WaitGroup, i *integration.Integration, instanceLookUp map[string]string) {
 	defer wg.Done()
 
 	const sqlQuery = `
@@ -53,7 +53,16 @@ func collectInventory(db *sql.DB, wg *sync.WaitGroup, i *integration.Integration
 		}
 
 		// Retrieve or create the instance entity
-		e, err := i.Entity(strconv.Itoa(inventoryResultRow.instID), "instance")
+		instanceID := strconv.Itoa(inventoryResultRow.instID)
+		instanceName := func() string {
+			if name, ok := instanceLookUp[instanceID]; ok {
+				return name
+			}
+
+			return instanceID
+		}()
+
+		e, err := i.Entity(instanceName, "instance")
 		if err != nil {
 			log.Error("Failed to get instance entity %d", inventoryResultRow.instID)
 			continue

--- a/src/inventory_test.go
+++ b/src/inventory_test.go
@@ -24,13 +24,17 @@ func TestPopulateInventory(t *testing.T) {
 	var wg sync.WaitGroup
 	i, _ := integration.New("oracletest", "0.0.1")
 
+	lookup := map[string]string{
+		"1": "MyInstance",
+	}
+
 	wg.Add(1)
-	go collectInventory(db, &wg, i)
+	go collectInventory(db, &wg, i, lookup)
 	wg.Wait()
 
 	marshalled, err := i.MarshalJSON()
 
-	expectedMarshalled := `{"name":"oracletest","protocol_version":"2","integration_version":"0.0.1","data":[{"entity":{"name":"1","type":"instance"},"metrics":[],"inventory":{"testname":{"description":"this is a test","value":"testvalue"}},"events":[]}]}`
+	expectedMarshalled := `{"name":"oracletest","protocol_version":"2","integration_version":"0.0.1","data":[{"entity":{"name":"MyInstance","type":"instance"},"metrics":[],"inventory":{"testname":{"description":"this is a test","value":"testvalue"}},"events":[]}]}`
 	if string(marshalled) != expectedMarshalled {
 		t.Errorf("Expected %s, got %s", expectedMarshalled, marshalled)
 	}

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -110,7 +110,7 @@ func parseTablespaceWhitelist() error {
 }
 
 func createInstanceIDLookup(db *sql.DB) (map[string]string, error) {
-	const instanceQuery = "select instance_name, instance_number, inst_id from gv$instance;"
+	const instanceQuery = "select instance_name, inst_id from gv$instance;"
 
 	rows, err := db.Query(instanceQuery)
 	if err != nil {
@@ -120,7 +120,7 @@ func createInstanceIDLookup(db *sql.DB) (map[string]string, error) {
 
 	var instance struct {
 		Name string
-		ID   interface{}
+		ID   int
 	}
 
 	lookup := make(map[string]string)

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -110,7 +110,7 @@ func parseTablespaceWhitelist() error {
 }
 
 func createInstanceIDLookup(db *sql.DB) (map[string]string, error) {
-	const instanceQuery = "select instance_name, inst_id from gv$instance;"
+	const instanceQuery = `SELECT INSTANCE_NAME, INST_ID FROM gv$instance`
 
 	rows, err := db.Query(instanceQuery)
 	if err != nil {

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -110,7 +110,9 @@ func parseTablespaceWhitelist() error {
 }
 
 func createInstanceIDLookup(db *sql.DB) (map[string]string, error) {
-	const instanceQuery = `SELECT INSTANCE_NAME, INST_ID FROM gv$instance`
+	const instanceQuery = `SELECT 
+		INSTANCE_NAME, INST_ID 
+		FROM gv$instance`
 
 	rows, err := db.Query(instanceQuery)
 	if err != nil {

--- a/src/oracledb_test.go
+++ b/src/oracledb_test.go
@@ -72,7 +72,9 @@ func Test_createInstanceIDLookup_QueryFail(t *testing.T) {
 	}
 
 	mock.
-		ExpectQuery(`SELECT INSTANCE_NAME, INST_ID FROM gv\$instance`).
+		ExpectQuery(`SELECT 
+		INSTANCE_NAME, INST_ID 
+		FROM gv\$instance`).
 		WillReturnError(errors.New("error"))
 
 	_, err = createInstanceIDLookup(db)
@@ -89,7 +91,9 @@ func Test_createInstanceIDLookup(t *testing.T) {
 	}
 
 	mock.
-		ExpectQuery(`SELECT INSTANCE_NAME, INST_ID FROM gv\$instance`).
+		ExpectQuery(`SELECT 
+		INSTANCE_NAME, INST_ID 
+		FROM gv\$instance`).
 		WillReturnRows(
 			sqlmock.NewRows([]string{"INSTANCE_NAME", "INST_ID"}).
 				AddRow("one", 1).

--- a/src/oracledb_test.go
+++ b/src/oracledb_test.go
@@ -72,7 +72,7 @@ func Test_createInstanceIDLookup_QueryFail(t *testing.T) {
 	}
 
 	mock.
-		ExpectQuery(`select instance_name, inst_id from gv\$instance;`).
+		ExpectQuery(`SELECT INSTANCE_NAME, INST_ID FROM gv\$instance`).
 		WillReturnError(errors.New("error"))
 
 	_, err = createInstanceIDLookup(db)
@@ -89,7 +89,7 @@ func Test_createInstanceIDLookup(t *testing.T) {
 	}
 
 	mock.
-		ExpectQuery(`select instance_name, inst_id from gv\$instance;`).
+		ExpectQuery(`SELECT INSTANCE_NAME, INST_ID FROM gv\$instance`).
 		WillReturnRows(
 			sqlmock.NewRows([]string{"INSTANCE_NAME", "INST_ID"}).
 				AddRow("one", 1).


### PR DESCRIPTION
#### Description of the changes

Made it so Instances now have human readable names rather than instance ids in their name. Still use instance ID as a fall back.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
