### PR TITLE
Allow for FPM to be ran in a container instead

### DIFF
--- a/Makefile-package.mk
+++ b/Makefile-package.mk
@@ -48,4 +48,9 @@ rpm: prep-pkg-env
 	@mkdir -p $(PACKAGES_DIR)/rpm
 	@fpm $(FPM_COMMON_OPTIONS) $(FPM_RPM_OPTIONS) .
 
+docker-rpm: prep-pkg-env
+	@echo "=== Main === [ rpm ]: building RPM package..."
+	@mkdir -p $(PACKAGES_DIR)/rpm
+	@docker run -it --rm -v $(PWD):/fpm -w /fpm cyberious/fpm make rpm
+
 .PHONY: package create-bins prep-pkg-env $(PACKAGE_TYPES)


### PR DESCRIPTION
#### FPM in container
Create a make entry to be able to run FPM inside of a container rather than on the host machine.

#### PR Review Checklist
### Travis Fields

### Reviewer

- [x] review code for readability
- [x] verify that high risk behavior changes are well tested
- [x] check license for any new external dependency
- [x] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
