### PR TITLE
Add log message if oracle home is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.1.4 - 2019-03-19
-### Fixed
-- Use correct protocol version
+### Added
+- Log error message if ORACLE_HOME is unset
 
 ## 1.1.3 - 2019-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.4 - 2019-03-19
+### Fixed
+- Use correct protocol version
+
 ## 1.1.3 - 2019-02-04
 ### Fixed
 - Use correct protocol version

--- a/oracledb-config.yml.sample
+++ b/oracledb-config.yml.sample
@@ -16,6 +16,8 @@ instances:
       password: password
       # True if the monitoring user is a SysDBA. If omitted, defaults to false.
       is_sys_dba: true
+      # The location of ORACLE_HOME
+      oracle_home: /u01/app/oracle/product/version/database
       # True if the monitoring user is a SysOper. If omitted, defaults to false.
       is_sys_oper: false
       # A JSON array of tablespaces to collect. If omitted, collects all tablespaces.

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -41,6 +41,11 @@ func main() {
 	i, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	exitOnErr(err)
 
+  if oracleHome := os.Getenv("ORACLE_HOME"); oracleHome == "" {
+    log.Error("Required argument oracle_home is unset")
+    os.Exit(1)
+  }
+
 	// parse tablespace whitelist
 	err = parseTablespaceWhitelist()
 	exitOnErr(err)

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -28,7 +28,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.oracledb"
-	integrationVersion = "1.1.3"
+	integrationVersion = "1.1.4"
 )
 
 var (

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -41,10 +41,10 @@ func main() {
 	i, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	exitOnErr(err)
 
-  if oracleHome := os.Getenv("ORACLE_HOME"); oracleHome == "" {
-    log.Error("Required argument oracle_home is unset")
-    os.Exit(1)
-  }
+	if oracleHome := os.Getenv("ORACLE_HOME"); oracleHome == "" {
+		log.Error("Required argument oracle_home is unset")
+		os.Exit(1)
+	}
 
 	// parse tablespace whitelist
 	err = parseTablespaceWhitelist()


### PR DESCRIPTION
#### Description of the changes

Adds a log message if oracle home is unset and also adds a configuration example for setting oracle_home as an argument

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
