### PR TITLE
Returning function if query error

### DIFF
--- a/src/inventory.go
+++ b/src/inventory.go
@@ -41,6 +41,7 @@ func collectInventory(db *sql.DB, wg *sync.WaitGroup, i *integration.Integration
 	rows, err := db.Query(sqlQuery)
 	if err != nil {
 		log.Error("Failed to collect inventory: %s", err)
+		return
 	}
 	defer func() {
 		err := rows.Close()


### PR DESCRIPTION
#### Description of the changes

This avoids a later "panic" in the `rows.Next()`. I suspect this may cause also the process to be blocked, since `rows.Next()` is a blocking operation and some unexpected, non-nil `rows` variable could block the whole process.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
