### PR TITLE
Collect tablespace size concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.6 - 2019-11-08
+### Fixed
+- Run all DB queries concurrently to avoid deadlock
+
 ## 2.1.5 - 2019-11-07
 ### Fixed
 - Avoid panicking or blocking when inventory connection fails.

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -20,12 +20,11 @@ func collectMetrics(db *sql.DB, populaterWg *sync.WaitGroup, i *integration.Inte
 	metricChan := make(chan newrelicMetricSender, 100) // large buffer for speed
 
 	// Separate logic is needed to see if we should even collect tablespaces
-  // Collect tablespaces first so the list query completes before other queries are run
-  collectorWg.Add(1)
+	// Collect tablespaces first so the list query completes before other queries are run
+	collectorWg.Add(25)
 	go collectTableSpaces(db, &collectorWg, metricChan)
 
 	// Create a goroutine for each of the metric groups to collect
-	collectorWg.Add(24)
 	go oracleCDBDatafilesOffline.Collect(db, &collectorWg, metricChan)
 	go oraclePDBDatafilesOffline.Collect(db, &collectorWg, metricChan)
 	go oraclePDBNonWrite.Collect(db, &collectorWg, metricChan)
@@ -144,7 +143,7 @@ const maxTablespaces = 200
 const tablespaceCountQuery = `SELECT count(1) FROM DBA_TABLESPACES WHERE TABLESPACE_NAME <> 'TEMP'`
 
 func collectTableSpaces(db *sql.DB, wg *sync.WaitGroup, metricChan chan<- newrelicMetricSender) {
-  defer wg.Done()
+	defer wg.Done()
 
 	// Get count from database
 	if tablespaceWhiteList == nil {

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -203,7 +203,8 @@ func Test_collectTableSpaces_NoWhitelist_Ok(t *testing.T) {
 	metricChan := make(chan newrelicMetricSender, 10)
 	var collectorWg sync.WaitGroup
 
-	collectTableSpaces(db, &collectorWg, metricChan)
+	collectorWg.Add(1)
+	go collectTableSpaces(db, &collectorWg, metricChan)
 
 	collectorWg.Wait()
 

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -31,7 +31,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.oracledb"
-	integrationVersion = "2.1.4"
+	integrationVersion = "2.1.6"
 )
 
 var (

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -70,14 +70,12 @@ func main() {
 	instanceLookUp, err := createInstanceIDLookup(db)
 	exitOnErr(err)
 
-	if args.All() {
-		populaterWg.Add(2)
-		go collectMetrics(db, &populaterWg, i, instanceLookUp)
-		go collectInventory(db, &populaterWg, i, instanceLookUp)
-	} else if args.Metrics {
+	if args.HasMetrics() {
 		populaterWg.Add(1)
 		go collectMetrics(db, &populaterWg, i, instanceLookUp)
-	} else if args.Inventory {
+	}
+
+  if args.HasInventory() {
 		populaterWg.Add(1)
 		go collectInventory(db, &populaterWg, i, instanceLookUp)
 	}

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -75,7 +75,7 @@ func main() {
 		go collectMetrics(db, &populaterWg, i, instanceLookUp)
 	}
 
-  if args.HasInventory() {
+	if args.HasInventory() {
 		populaterWg.Add(1)
 		go collectInventory(db, &populaterWg, i, instanceLookUp)
 	}


### PR DESCRIPTION
#### Description of the changes
The issue can be reliably reproduced by adding a 2-second sleep to the beginning of the `collectTableSpaces` function. 

We previously attempted to collect the number of tablespaces on the main metrics goroutine, but I believe this may have been causing a race condition because the integration would block on opening a database connection if the other goroutines consumed all the connections first. So, instead, we should kick off the collection jobs concurrently, then start consuming metrics (and closing rows) immediately. 

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
