### PR TITLE
fix: fix sample name is custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.5.1 (2020-07-30)
+### Fixed
+- Fixed case where sample name for custoem metrics was not being set properly
+
 ## 2.5.0 (2020-06-08)
 ### Added
 - Custom query YAML configuration

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -115,8 +115,10 @@ func populateMetrics(metricChan <-chan newrelicMetricSender, i *integration.Inte
 				return instanceID
 			}()
 
+			sampleName := metricSender.metadata["sampleName"]
+
 			for _, row := range metricSender.customMetrics {
-				ms := createCustomMetricSet(instanceName, i)
+				ms := createCustomMetricSet(sampleName, instanceName, i)
 				for key, val := range row {
 					sanitized := sanitizeValue(val)
 					inferredMetricType := func() nrmetric.SourceType {
@@ -215,7 +217,7 @@ func getOrCreateMetricSet(entityIdentifier string, entityType string, m map[stri
 	return newSet
 }
 
-func createCustomMetricSet(instanceID string, i *integration.Integration) *nrmetric.Set {
+func createCustomMetricSet(sampleName string, instanceID string, i *integration.Integration) *nrmetric.Set {
 	endpointIDAttr := integration.IDAttribute{Key: "endpoint", Value: fmt.Sprintf("%s:%s", args.Hostname, args.Port)}
 	serviceIDAttr := integration.IDAttribute{Key: "serviceName", Value: args.ServiceName}
 	e, _ := i.EntityReportedVia( //can't error if both name and namespace are defined
@@ -226,7 +228,7 @@ func createCustomMetricSet(instanceID string, i *integration.Integration) *nrmet
 		serviceIDAttr,
 	)
 
-	return e.NewMetricSet("OracleCustomSample", nrmetric.Attr("entityName", "ora-instance:"+instanceID), nrmetric.Attr("displayName", instanceID))
+	return e.NewMetricSet(sampleName, nrmetric.Attr("entityName", "ora-instance:"+instanceID), nrmetric.Attr("displayName", instanceID))
 }
 
 // maxTablespaces is the maximum amount of Tablespaces that can be collect.

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/infra-integrations-sdk/persist"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCollectMetrics(t *testing.T) {
@@ -214,4 +216,77 @@ func Test_collectTableSpaces_NoWhitelist_Ok(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("Expectations not met: %s", err.Error())
 	}
+}
+
+func Test_PopulateMetrics_FromCustomQueryFile(t *testing.T) {
+	t.Skip("this causes other tests to fail for some reason unknown to me")
+
+	qf, err := filepath.Abs(filepath.Join("..", "test", "fixtures", "custom_query_multi.yml"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	args = argumentList{
+		Hostname:            "testhost",
+		Port:                "1234",
+		ServiceName:         "testServiceName",
+		CustomMetricsConfig: qf,
+	}
+	defer func() { args = argumentList{} }()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Error(err)
+	}
+
+	mock.MatchExpectationsInOrder(false)
+
+	// there are 2 queries, so this query will be called 2 times
+	columns := []string{"val1"}
+	mock.ExpectQuery("SELECT.*FROM v\\$instance").WillReturnRows(
+		sqlmock.NewRows(columns).AddRow("1"),
+	)
+
+	mock.ExpectQuery("SELECT.*FROM v\\$instance").WillReturnRows(
+		sqlmock.NewRows(columns).AddRow("1"),
+	)
+
+	// queries from query file
+	columns = []string{"val1", "val2"}
+	mock.ExpectQuery("SELECT.*FROM numbers.*").WillReturnRows(
+		sqlmock.NewRows(columns).AddRow("one", "two"),
+	)
+
+	mock.ExpectQuery("SELECT.*FROM somewhere.*").WillReturnRows(
+		sqlmock.NewRows(columns).AddRow("something", "otherthing"),
+	)
+
+	sqlxDb := sqlx.NewDb(db, "sqlmock")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	ch := make(chan newrelicMetricSender)
+
+	results := []newrelicMetricSender{}
+
+	PopulateCustomMetricsFromFile(sqlxDb, &wg, ch, args.CustomMetricsConfig)
+
+	go func() {
+		for {
+			select {
+			case result := <-ch:
+				results = append(results, result)
+			default:
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, 2, len(results))
 }

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -34,7 +34,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.oracledb"
-	integrationVersion = "2.5.0"
+	integrationVersion = "2.5.1"
 )
 
 var (

--- a/test/fixtures/custom_query_multi.yml
+++ b/test/fixtures/custom_query_multi.yml
@@ -1,0 +1,30 @@
+---
+queries:
+  # Metric names are set to the column names in the query results
+  - query: >-
+      SELECT
+        one, two
+      FROM numbers
+    
+    # If not set explicitly here, metric type will default to 
+    # 'gauge' for numbers and 'attribute' for strings
+    metric_types:
+      one: gauge
+      two: gauge
+
+    # If unset, sample_name defaults to OracleCustomSample
+    sample_name: MyCustomSample
+  - query: >-
+      SELECT
+        something as "something",
+        otherthing as "otherthing"
+      FROM somewhere
+    
+    # If not set explicitly here, metric type will default to 
+    # 'gauge' for numbers and 'attribute' for strings
+    metric_types:
+      something: gauge
+      otherthing: gauge
+
+    # If unset, sample_name defaults to OracleCustomSample
+    sample_name: MyCustomSample


### PR DESCRIPTION
When using a custom metrics file, the sample name was always being set to the default, ignoring the configured name in the file
