### PR TITLE
ci: dynamic repo access_point_host for pre/release pipelines

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -95,6 +95,7 @@ jobs:
           tag: ${{env.TAG}}
           app_name: "nri-${{env.INTEGRATION}}"
           repo_name: ${{ env.ORIGINAL_REPO_NAME }}
+          access_point_host: "staging"
           schema: "custom"
           schema_url: "https://raw.githubusercontent.com/newrelic/nri-${{ env.INTEGRATION }}/${{ env.TAG }}/build/s3-publish-schema.yml"
           aws_region: "us-east-1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
           tag: ${{env.TAG}}
           app_name: "nri-${{env.INTEGRATION}}"
           repo_name: ${{ env.ORIGINAL_REPO_NAME }}
+          access_point_host: "production"
           schema: "custom"
           schema_url: "https://raw.githubusercontent.com/newrelic/nri-${{ env.INTEGRATION }}/${{ env.TAG }}/build/s3-publish-schema.yml"
           aws_region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
Added `access_point_host` variable to release/prerelease pipelines in order to use different repositories in production and staging.
