### PR TITLE
ci: separate Amazon Linux 2 repository

### DIFF
--- a/build/s3-publish-schema.yml
+++ b/build/s3-publish-schema.yml
@@ -46,3 +46,9 @@
         - 12.2
         - 12.3
         - 12.4
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2
+


### PR DESCRIPTION
Change Amazon Linux 2 repository as infrastructure-agent repository location for Amazon Linux 2 is going to be changed.