### PR TITLE
Fix missing event type on custom metric config

### DIFF
--- a/src/metric_definitions.go
+++ b/src/metric_definitions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/log"
 )
 
-const defaultCustomMetricType = "OracleCustomSample"
+const defaultCustomSampleType = "OracleCustomSample"
 
 // oracleMetric is a storage struct for the information needed to parse
 // a metric from a query and create a newrelicMetric
@@ -185,7 +185,7 @@ func (mg *customMetricGroup) Collect(db *sqlx.DB, wg *sync.WaitGroup, metricChan
 		isCustom: true,
 		metadata: map[string]string{
 			"instanceID": instanceID,
-			"sampleName": defaultCustomMetricType,
+			"sampleName": defaultCustomSampleType,
 		},
 	}
 

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -359,7 +359,7 @@ func CollectCustomConfig(db *sqlx.DB, metricChan chan<- newrelicMetricSender, cf
 
 	sampleName := func() string {
 		if cfg.SampleName == "" {
-			return defaultCustomMetricType
+			return defaultCustomSampleType
 		}
 		return cfg.SampleName
 	}()


### PR DESCRIPTION
This PR fixes missing default "OracleCustomSample" event type from custom queries on the oracledb-config.yml

Linked issue: https://github.com/newrelic/nri-oracledb/issues/85