### PR TITLE
fix: use go 1.19 to asure compatibilty with older OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 
 ## Unreleased
+### bugfix
+- Restore golang version to 1.19 to ensure compatibility
 
 ## v3.6.0 - 2023-08-08
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.6-bookworm
+FROM golang:1.19.10-bookworm
 
 ARG GH_VERSION='1.9.2'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-oracledb
 
-go 1.20
+go 1.19
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
1.20 compiled binary doesn't work on OS with glic versions different from `2.32`. Example in ubuntu focal (20.04):

```
/var/db/newrelic-infra/newrelic-integrations/bin/nri-oracledb -show_version
/var/db/newrelic-infra/newrelic-integrations/bin/nri-oracledb: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /var/db/newrelic-infra/newrelic-integrations/bin/nri-oracledb)
``` 

Additional context:
- Failing pre-release workflow: https://github.com/newrelic/nri-oracledb/actions/runs/5797323168/job/15712679934#step:11:1122
- https://github.com/golang/go/issues/57328
- https://github.com/golang/go/issues/58550