### PR TITLE
fix: restore golang image to buster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- Restore golang docker image to buster
+
 ## v3.6.1 - 2023-08-15
 
 ### 🐞 Bug fixes

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.10-bookworm
+FROM golang:1.19.10-buster
 
 ARG GH_VERSION='1.9.2'
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,6 @@
+# Changing the container's glib version might cause issues.
+# In the past, we experienced problems when bumping Go versions and using the `bookworm` versions.
+# glib issue: https://github.com/golang/go/issues/58550#issuecomment-1597411275
 FROM golang:1.19.10-buster
 
 ARG GH_VERSION='1.9.2'


### PR DESCRIPTION
The pipeline is still [broken](https://github.com/newrelic/nri-oracledb/actions/runs/5867414580/job/15967713772) even after https://github.com/newrelic/nri-oracledb/pull/135. 

Restoring back to use the `buster` image.