### PR TITLE
chore: bump golang version to 1.19.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Bugfix
+- Bump go version to go 1.19.13
+
 ## v3.7.4 - 2024-04-30
 
 ### ⛓️ Dependencies

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # Changing the container's glib version might cause issues.
 # In the past, we experienced problems when bumping Go versions and using the `bookworm` versions.
 # glib issue: https://github.com/golang/go/issues/58550#issuecomment-1597411275
-FROM golang:1.19.10-buster
+FROM golang:1.19.13-buster
 
 ARG GH_VERSION='1.9.2'
 


### PR DESCRIPTION
This PR bumps golang version to 1.19.13 since there are additional steps to upgrade to the latest, check #133 for details.