### PR TITLE
Feat/avoid panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- A wrong custom query could cause a panic. Now the error is managed properly.
+ 
 ## v3.8.0 - 2024-06-17
 
 ### 🛡️ Security notices

--- a/src/database/db_wrapper.go
+++ b/src/database/db_wrapper.go
@@ -50,7 +50,7 @@ func (r *RowsWrapper) Next() bool {
 }
 
 func (r *RowsWrapper) Close() {
-	if r == nil {
+	if r.Rows == nil {
 		return
 	}
 	err := r.Rows.Close()
@@ -87,7 +87,7 @@ func (rx *RowsxWrapper) ScannedRowsCount() int {
 }
 
 func (rx *RowsxWrapper) Close() {
-	if rx == nil {
+	if rx.Rows == nil {
 		return
 	}
 	err := rx.Rows.Close()

--- a/src/database/db_wrapper.go
+++ b/src/database/db_wrapper.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"errors"
+	"github.com/newrelic/infra-integrations-sdk/log"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -15,7 +16,6 @@ type Rows interface {
 	ScannedRowsCount() int
 	MapScan(dest map[string]interface{}) error
 	Columns() ([]string, error)
-	Close() error
 }
 
 type DBWrapper struct {
@@ -49,6 +49,13 @@ func (r *RowsWrapper) Next() bool {
 	return n
 }
 
+func (r *RowsWrapper) Close() {
+	err := r.Rows.Close()
+	if err != nil {
+		log.Error("Failed to close rows: %s", err)
+	}
+}
+
 // ScannedRowsCount returns the number of rows iterated with Next
 func (r *RowsWrapper) ScannedRowsCount() int {
 	return r.count
@@ -74,4 +81,11 @@ func (rx *RowsxWrapper) Next() bool {
 // ScannedRowsCount returns the number of rows iterated with Next
 func (rx *RowsxWrapper) ScannedRowsCount() int {
 	return rx.count
+}
+
+func (rx *RowsxWrapper) Close() {
+	err := rx.Rows.Close()
+	if err != nil {
+		log.Error("Failed to close rows: %s", err)
+	}
 }

--- a/src/database/db_wrapper.go
+++ b/src/database/db_wrapper.go
@@ -50,6 +50,9 @@ func (r *RowsWrapper) Next() bool {
 }
 
 func (r *RowsWrapper) Close() {
+	if r == nil {
+		return
+	}
 	err := r.Rows.Close()
 	if err != nil {
 		log.Error("Failed to close rows: %s", err)
@@ -84,6 +87,9 @@ func (rx *RowsxWrapper) ScannedRowsCount() int {
 }
 
 func (rx *RowsxWrapper) Close() {
+	if rx == nil {
+		return
+	}
 	err := rx.Rows.Close()
 	if err != nil {
 		log.Error("Failed to close rows: %s", err)

--- a/src/inventory.go
+++ b/src/inventory.go
@@ -52,10 +52,7 @@ func (ic *inventoryCollector) collect() {
 	}
 	defer func() {
 		checkAndLogEmptyQueryResult(sqlQuery, rows)
-		err := rows.Close()
-		if err != nil {
-			log.Error("Failed to close rows: %s", err)
-		}
+		rows.Close()
 	}()
 
 	for rows.Next() {

--- a/src/metric_definitions.go
+++ b/src/metric_definitions.go
@@ -67,10 +67,7 @@ func (mg *oracleMetricGroup) Collect(db database.DBWrapper, wg *sync.WaitGroup, 
 	}
 	defer func() {
 		checkAndLogEmptyQueryResult(query, rows)
-		err := rows.Close()
-		if err != nil {
-			log.Error("Failed to close rows: %s", err)
-		}
+		rows.Close()
 	}()
 
 	if err = mg.metricsGenerator(rows, mg.metrics, metricChan); err != nil {
@@ -202,12 +199,7 @@ func (mg *customMetricGroup) Collect(db database.DBWrapper, wg *sync.WaitGroup, 
 		log.Error("Failed to execute query %s: %s", formatQueryForLogging(mg.Query), err)
 		return
 	}
-	defer func() {
-		err := rows.Close()
-		if err != nil {
-			log.Error("Failed to close rows: %s", err)
-		}
-	}()
+	defer rows.Close()
 
 	var instanceID string
 	for rows.Next() {
@@ -218,17 +210,12 @@ func (mg *customMetricGroup) Collect(db database.DBWrapper, wg *sync.WaitGroup, 
 		}
 	}
 
-	rows, err = db.Queryx(mg.Query)
+	rowsCustom, err := db.Queryx(mg.Query)
 	if err != nil {
 		log.Error("Failed to execute query %s: %s", formatQueryForLogging(mg.Query), err)
 		return
 	}
-	defer func() {
-		err := rows.Close()
-		if err != nil {
-			log.Error("Failed to close rows: %s", err)
-		}
-	}()
+	defer rowsCustom.Close()
 
 	sender := newrelicMetricSender{
 		isCustom: true,

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -340,10 +340,7 @@ func CollectCustomConfig(db database.DBWrapper, metricChan chan<- newrelicMetric
 
 	defer func() {
 		checkAndLogEmptyQueryResult(instanceQuery, instanceRows)
-		err = instanceRows.Close()
-		if err != nil {
-			log.Error("Failed to close rows: %s", err)
-		}
+		instanceRows.Close()
 	}()
 
 	var instanceID string
@@ -362,7 +359,7 @@ func CollectCustomConfig(db database.DBWrapper, metricChan chan<- newrelicMetric
 	}
 	defer func() {
 		checkAndLogEmptyQueryResult(cfg.Query, rows)
-		_ = rows.Close()
+		rows.Close()
 	}()
 
 	sampleName := func() string {

--- a/src/oracledb.go
+++ b/src/oracledb.go
@@ -197,10 +197,7 @@ func createInstanceIDLookup(db database.DBWrapper) (map[string]string, error) {
 
 	defer func() {
 		checkAndLogEmptyQueryResult(instanceQuery, rows)
-		err := rows.Close()
-		if err != nil {
-			log.Error("Failed to close rows: %s", err)
-		}
+		rows.Close()
 	}()
 
 	var instance struct {


### PR DESCRIPTION
When running the custom query we were reusing the very same name. 
Therefore, on fail we were had already a registered a refer that was being called on a nil variable
```go
	rows, err = db.Queryx(mg.Query)
        if err != nil {
		log.Error("Failed to execute query %s: %s", formatQueryForLogging(mg.Query), err)
		return
	}
```

I have also refactored a bit how defers were implemented

