### PR TITLE
NR-410032: fix lockedAccounts metric

### DIFF
--- a/src/metric_definitions.go
+++ b/src/metric_definitions.go
@@ -85,6 +85,8 @@ func getInstanceIDString(originalID interface{}) string {
 		return id.String()
 	case int:
 		return strconv.Itoa(id)
+	case int64:
+		return strconv.FormatInt(id, 10)
 	case string:
 		return id
 	default:
@@ -885,7 +887,6 @@ var oracleLockedAccounts = oracleMetricGroup{
         cdb_users a,
         cdb_pdbs b
       WHERE a.con_id = b.con_id
-        AND username IN ('SYS', 'SYSTEM', 'DBSNMP')
         AND a.account_status != 'OPEN'
     ) l,
     gv$instance i


### PR DESCRIPTION
- The `lockedAccounts` metric was previously limited to reporting locked status for only 'SYS', 'SYSTEM', and 'DBSNMP' users. This change updates the metric to query and report the locked status for all database accounts.

**Verification:**

- Added three test users (`user3`, `user4`, `users 5`).

**with locks:** : Verified that the metric correctly reports the total number of locked users

- [x]  With locks query result

<img width="1562" alt="db locks" src="https://github.com/user-attachments/assets/db63d4f0-9ec7-4dd7-9fec-6901dbd34374" />

- [x]  With locks metrics:

<img width="1629" alt="locked_metrics" src="https://github.com/user-attachments/assets/39b428db-da38-4374-8b3e-31756452489e" />


**Without locks**

- [x] Without locks query result

<img width="1629" alt="unlock" src="https://github.com/user-attachments/assets/dffdad03-bbb1-4d3c-9129-99cbb6a41516" />

- [x] Without locks metrics:

<img width="1629" alt="unlock_metrics" src="https://github.com/user-attachments/assets/de3a3821-87ad-4b8e-948c-7649baeeba41" />

