### PR TITLE
fix: Instance ID for a Standalone Oracle DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix 
+- Fix fetch instance ID query for non-cdb/pdb 
+
 ## v3.10.1 - 2025-06-30
 
 ### 🐞 Bug fixes

--- a/src/metric_definitions.go
+++ b/src/metric_definitions.go
@@ -202,9 +202,15 @@ func handleLockedAccountsMetricGroup(mg *oracleMetricGroup, db database.DBWrappe
 	if !strings.EqualFold(isCDB, "YES") {
 		mg.sqlQuery = func(metrics []*oracleMetric) string {
 			query := `
-				SELECT 0 AS INST_ID, COUNT(1) AS LOCKED_ACCOUNTS
-				FROM dba_users
-				WHERE account_status != 'OPEN'
+				SELECT NVL(INST_ID, 0) AS INST_ID, LOCKED_ACCOUNTS
+				FROM (
+					SELECT
+						INST_ID,
+						(SELECT COUNT(1) 
+						FROM dba_users
+						WHERE account_status != 'OPEN') AS LOCKED_ACCOUNTS
+					FROM gv$instance i
+				)
 				`
 			return query
 		}


### PR DESCRIPTION
Test Result:

<details><summary>Details</summary>
<p>

{
  "name": "com.newrelic.oracledb",
  "protocol_version": "3",
  "integration_version": "0.0.0",
  "data": [
    {
      "entity": {
        "name": "ORCLCDB",
        "type": "ora-instance",
        "id_attributes": [
          {
            "Key": "endpoint",
            "Value": "XX.XX.XX.XXX:1521"
          },
          {
            "Key": "serviceName",
            "Value": "ORCLCDB"
          }
        ]
      },
      "metrics": [
        {
          "db.cpuUsagePerSecond": 0.0498033988670443,
          "db.executionsPerSecond": 0.2,
          "db.hostCpuUtilization": 1.10626885685551,
          "db.sessionCount": 73,
          "db.sqlServiceResponseTime": 0.00464610091743119,
          "db.totalIndexScansPerSecond": 0.0499833388870377,
          "db.totalTableScansPerSecond": 0,
          "dbID": "2975803496",
          "disk.blocksRead": 0,
          "disk.blocksWritten": 0,
          "disk.physicalReadBytesPerSecond": 31392.2025991336,
          "disk.physicalReadIoRequestsPerSecond": 1.91602799066978,
          "disk.physicalReadsPerSecond": 0,
          "disk.physicalWriteTotalIoRequestsPerSecond": 0.349883372209264,
          "disk.physicalWritesPerSecond": 0,
          "disk.readTimeInMilliseconds": 0,
          "disk.reads": 0,
          "disk.writeTimeInMilliseconds": 0,
          "disk.writes": 0,
          "displayName": "ORCLCDB",
          "entityName": "ora-instance:ORCLCDB",
          "event_type": "OracleDatabaseSample",
          "globalName": "ORCLCDB",
          "lockedAccounts": 34,
          "longRunningQueries": 0,
          "memory.bufferCacheHitRatio": 0,
          "memory.pgaMaxSizeInBytes": 104857600,
          "network.ioMegabytesPerSecond": 0.0333222259246918,
          "network.ioRequestsPerSecond": 2.26591136287904,
          "network.trafficBytePerSecond": 50.8830389870043,
          "query.transactionsPerSecond": 0,
          "redoLog.waits": 263,
          "reportingEndpoint": "XX.XX.XX.XXX:1521",
          "rollbackSegments.gets": 2120,
          "rollbackSegments.ratioWait": 0,
          "rollbackSegments.waits": 0,
          "sga.bufferBusyWaits": 3,
          "sga.fixedSizeInBytes": 8897072,
          "sga.hitRatio": 0.9558744976344304,
          "sga.logBufferAllocationRetriesRatio": 0,
          "sga.logBufferRedoAllocationRetries": 0,
          "sga.logBufferRedoEntries": 7270,
          "sga.redoBuffersInBytes": 7876608,
          "sga.sharedPoolDictCacheMissRatio": 0.0888053966356417,
          "sga.sharedPoolLibraryCacheHitRatio": 0.39710444674250256,
          "sga.sharedPoolLibraryCacheReloadRatio": 0.0017235519735883866,
          "sga.sharedPoolLibraryCacheShareableMemoryPerStatementInBytes": 8142415,
          "sga.sharedPoolLibraryCacheShareableMemoryPerUserInBytes": 36250,
          "sga.ugaTotalMemoryInBytes": 67963448,
          "sorts.diskInBytes": 0,
          "sorts.memoryInBytes": 4874
        }
      ]
    }
  ]
}

</p>
</details> 